### PR TITLE
multibalance.plot issues

### DIFF
--- a/R/plot.multibalance.R
+++ b/R/plot.multibalance.R
@@ -57,9 +57,9 @@ multibalance.plot <- function(tpsa, tmatch, grid=TRUE, cols) {
 		m <- tpsa2[!is.na(tpsa2[,paste('model', i, sep='')]),]
 		
 		bal <- covariateBalance(m[names(m) %in% names(covs)], 
-						  m[paste('model', i, sep='')], 
-						  m[paste('ps', i, sep='')],
-						  m[paste('strata', i, sep='')])
+						  m[, paste('model', i, sep='')], 
+						  m[, paste('ps', i, sep='')],
+						  m[, paste('strata', i, sep='')])
 		results <- rbind(results, data.frame(
 			covariate = row.names(bal$effect.sizes),
 			model = rep(i, ncol(covs)),

--- a/R/plot.multibalance.R
+++ b/R/plot.multibalance.R
@@ -16,7 +16,7 @@ utils::globalVariables(c('value','covariate','variable','model','group'))
 #' @export
 multibalance.plot <- function(tpsa, tmatch, grid=TRUE, cols) {
 	if(!missing(tmatch)) {
-		tpsa <- attr(results, 'triangle.psa', exact=TRUE)
+		tpsa <- attr(tmatch, 'triangle.psa', exact=TRUE)
 	}
 	
 	covs <- attr(tpsa, 'data')
@@ -24,13 +24,13 @@ multibalance.plot <- function(tpsa, tmatch, grid=TRUE, cols) {
 	if(missing(cols)) {
 		cols <- attr(m1$terms, 'term.labels')
 	}
-	covs <- covs[,cols]
+	covs <- covs[cols]
 	
 	#Recode factors. First we'll covert logicals and factors with two levels to integers
 	for(i in 1:ncol(covs)) {
-		if(class(covs[,i]) == 'logical') {
+		if(is.logical(covs[,i])) {
 			covs[,i] <- as.integer(covs[,i])
-		} else if(class(covs[,i]) == 'factor' & length(levels(covs[,i])) == 2) {
+		} else if(is.factor(covs[,i]) && length(levels(covs[,i])) == 2) {
 			covs[,i] <- as.integer(covs[,i])
 		}
 	}
@@ -56,10 +56,10 @@ multibalance.plot <- function(tpsa, tmatch, grid=TRUE, cols) {
 	for(i in 1:3) {
 		m <- tpsa2[!is.na(tpsa2[,paste('model', i, sep='')]),]
 		
-		bal <- covariateBalance(m[,names(m) %in% names(covs)], 
-						  m[,paste('model', i, sep='')], 
-						  m[,paste('ps', i, sep='')],
-						  m[,paste('strata', i, sep='')])
+		bal <- covariateBalance(m[names(m) %in% names(covs)], 
+						  m[paste('model', i, sep='')], 
+						  m[paste('ps', i, sep='')],
+						  m[paste('strata', i, sep='')])
 		results <- rbind(results, data.frame(
 			covariate = row.names(bal$effect.sizes),
 			model = rep(i, ncol(covs)),


### PR DESCRIPTION
Hello! 

I've had some problems with `multibalance.plot` recently and I would like to propose the following changes:

* When suppling `tmatch` as the only argument, the function breaks because it's looking for `results` which does not exist in the scope. I've changed this reference to `tmatch`, which seems to work.
* Certain instances of matrix subsetting (e.g., `covs[,cols]`) break if there is only one variable supplied by `cols` because the object reduces to a vector whereas it is usually expected to be a data.frame. I've changed these to use list subsetting such that the object will always be a data.frame regardless of the number of variables in `cols`.
* Class checks of the type `object == "class"` break if the `object` has multiple class attributes, so I changed them to be more robust (e.g., `is.logical`/`is.factor`). 

Thanks in advance for your attention!

Pavel